### PR TITLE
Release Hotfix 01

### DIFF
--- a/public/BalancingPresets/COTF.json
+++ b/public/BalancingPresets/COTF.json
@@ -167,8 +167,15 @@
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
             "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Wraith",
@@ -182,18 +189,43 @@
                 0
             ],
             "AntiFacecampPermitted": false,
-            "KillerIndvPerkBans": [],
+            "KillerIndvPerkBans": [
+                "150"
+            ],
             "KillerComboPerkBans": [],
-            "SurvivorIndvPerkBans": [],
+            "SurvivorIndvPerkBans": [
+                "13",
+                "21",
+                "34",
+                "36",
+                "38",
+                "39",
+                "44",
+                "57",
+                "76",
+                "112",
+                "121",
+                "85",
+                "111"
+            ],
             "SurvivorComboPerkBans": [],
             "SurvivorWhitelistedPerks": [],
             "SurvivorWhitelistedComboPerks": [],
             "KillerWhitelistedPerks": [],
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
-            "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "IndividualAddonBans": [
+                "\"All Seeing\" - Blood"
+            ],
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Hillbilly",
@@ -207,9 +239,23 @@
                 0
             ],
             "AntiFacecampPermitted": false,
-            "KillerIndvPerkBans": [],
+            "KillerIndvPerkBans": [
+                "150"
+            ],
             "KillerComboPerkBans": [],
-            "SurvivorIndvPerkBans": [],
+            "SurvivorIndvPerkBans": [
+                "13",
+                "21",
+                "34",
+                "36",
+                "38",
+                "39",
+                "44",
+                "57",
+                "76",
+                "112",
+                "121"
+            ],
             "SurvivorComboPerkBans": [],
             "SurvivorWhitelistedPerks": [],
             "SurvivorWhitelistedComboPerks": [],
@@ -217,8 +263,15 @@
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
             "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Nurse",
@@ -232,7 +285,14 @@
                 0
             ],
             "AntiFacecampPermitted": false,
-            "KillerIndvPerkBans": [],
+            "KillerIndvPerkBans": [
+                "150",
+                "132",
+                "155",
+                "159",
+                "204",
+                "220"
+            ],
             "KillerComboPerkBans": [],
             "SurvivorIndvPerkBans": [],
             "SurvivorComboPerkBans": [],
@@ -241,9 +301,23 @@
             "KillerWhitelistedPerks": [],
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
-            "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "IndividualAddonBans": [
+                "Bad Man Keepsake",
+                "Heavy Panting",
+                "Jenner's Last Breath",
+                "Campbell's Last Breath",
+                "Torn Bookmark",
+                "Matchbox"
+            ],
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Shape",
@@ -267,8 +341,15 @@
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
             "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Hag",
@@ -282,18 +363,46 @@
                 0
             ],
             "AntiFacecampPermitted": false,
-            "KillerIndvPerkBans": [],
+            "KillerIndvPerkBans": [
+                "150",
+                "200"
+            ],
             "KillerComboPerkBans": [],
-            "SurvivorIndvPerkBans": [],
+            "SurvivorIndvPerkBans": [
+                "13",
+                "21",
+                "34",
+                "36",
+                "38",
+                "39",
+                "44",
+                "57",
+                "76",
+                "112",
+                "121",
+                "85",
+                "111",
+                "123"
+            ],
             "SurvivorComboPerkBans": [],
             "SurvivorWhitelistedPerks": [],
             "SurvivorWhitelistedComboPerks": [],
             "KillerWhitelistedPerks": [],
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
-            "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "IndividualAddonBans": [
+                "Pussy Willow Catkins",
+                "Willow Wreath"
+            ],
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Doctor",
@@ -307,18 +416,46 @@
                 0
             ],
             "AntiFacecampPermitted": false,
-            "KillerIndvPerkBans": [],
+            "KillerIndvPerkBans": [
+                "150"
+            ],
             "KillerComboPerkBans": [],
-            "SurvivorIndvPerkBans": [],
+            "SurvivorIndvPerkBans": [
+                "1",
+                "13",
+                "21",
+                "34",
+                "36",
+                "38",
+                "39",
+                "44",
+                "57",
+                "76",
+                "92",
+                "112",
+                "121",
+                "26"
+            ],
             "SurvivorComboPerkBans": [],
             "SurvivorWhitelistedPerks": [],
             "SurvivorWhitelistedComboPerks": [],
             "KillerWhitelistedPerks": [],
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
-            "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "IndividualAddonBans": [
+                "\"Restraint\" - Class II",
+                "\"Restraint\" - Class III",
+                "\"Restraint\" - Carter's Notes"
+            ],
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Huntress",
@@ -332,18 +469,42 @@
                 0
             ],
             "AntiFacecampPermitted": false,
-            "KillerIndvPerkBans": [],
+            "KillerIndvPerkBans": [
+                "150"
+            ],
             "KillerComboPerkBans": [],
-            "SurvivorIndvPerkBans": [],
+            "SurvivorIndvPerkBans": [
+                "13",
+                "21",
+                "34",
+                "36",
+                "38",
+                "39",
+                "44",
+                "57",
+                "76",
+                "112",
+                "121"
+            ],
             "SurvivorComboPerkBans": [],
             "SurvivorWhitelistedPerks": [],
             "SurvivorWhitelistedComboPerks": [],
             "KillerWhitelistedPerks": [],
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
-            "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "IndividualAddonBans": [
+                "Glowing Concoction",
+                "Iridescent Head"
+            ],
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Cannibal",
@@ -357,18 +518,43 @@
                 0
             ],
             "AntiFacecampPermitted": false,
-            "KillerIndvPerkBans": [],
+            "KillerIndvPerkBans": [
+                "150"
+            ],
             "KillerComboPerkBans": [],
-            "SurvivorIndvPerkBans": [],
+            "SurvivorIndvPerkBans": [
+                "13",
+                "21",
+                "34",
+                "36",
+                "38",
+                "39",
+                "44",
+                "57",
+                "76",
+                "92",
+                "112",
+                "121"
+            ],
             "SurvivorComboPerkBans": [],
             "SurvivorWhitelistedPerks": [],
             "SurvivorWhitelistedComboPerks": [],
             "KillerWhitelistedPerks": [],
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
-            "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "IndividualAddonBans": [
+                "Begrimed Chains",
+                "Light Chassis"
+            ],
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Nightmare",
@@ -382,18 +568,44 @@
                 0
             ],
             "AntiFacecampPermitted": false,
-            "KillerIndvPerkBans": [],
+            "KillerIndvPerkBans": [
+                "150"
+            ],
             "KillerComboPerkBans": [],
-            "SurvivorIndvPerkBans": [],
+            "SurvivorIndvPerkBans": [
+                "21",
+                "34",
+                "36",
+                "38",
+                "39",
+                "44",
+                "57",
+                "76",
+                "92",
+                "112",
+                "121"
+            ],
             "SurvivorComboPerkBans": [],
             "SurvivorWhitelistedPerks": [],
             "SurvivorWhitelistedComboPerks": [],
             "KillerWhitelistedPerks": [],
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
-            "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "IndividualAddonBans": [
+                "Prototype Claws",
+                "Green Dress",
+                "Paint Thinner",
+                "Blue Dress"
+            ],
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Pig",
@@ -417,8 +629,15 @@
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
             "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Clown",
@@ -434,16 +653,41 @@
             "AntiFacecampPermitted": false,
             "KillerIndvPerkBans": [],
             "KillerComboPerkBans": [],
-            "SurvivorIndvPerkBans": [],
+            "SurvivorIndvPerkBans": [
+                "1",
+                "13",
+                "21",
+                "34",
+                "36",
+                "38",
+                "39",
+                "44",
+                "57",
+                "76",
+                "92",
+                "112",
+                "121"
+            ],
             "SurvivorComboPerkBans": [],
             "SurvivorWhitelistedPerks": [],
             "SurvivorWhitelistedComboPerks": [],
             "KillerWhitelistedPerks": [],
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
-            "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "IndividualAddonBans": [
+                "Cigar Box",
+                "Tattoo's Middle Finger",
+                "Redhead's Pinky Finger"
+            ],
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Spirit",
@@ -457,18 +701,49 @@
                 0
             ],
             "AntiFacecampPermitted": false,
-            "KillerIndvPerkBans": [],
+            "KillerIndvPerkBans": [
+                "150",
+                "132",
+                "155",
+                "159",
+                "204",
+                "220"
+            ],
             "KillerComboPerkBans": [],
-            "SurvivorIndvPerkBans": [],
+            "SurvivorIndvPerkBans": [
+                "34",
+                "32",
+                "35",
+                "63",
+                "64",
+                "67",
+                "78",
+                "82",
+                "103",
+                "115"
+            ],
             "SurvivorComboPerkBans": [],
             "SurvivorWhitelistedPerks": [],
             "SurvivorWhitelistedComboPerks": [],
             "KillerWhitelistedPerks": [],
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
-            "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "IndividualAddonBans": [
+                "Uchiwa",
+                "Yakuyoke Amulet",
+                "Dried Cherry Blossom",
+                "Mother-Daughter Ring",
+                "Kintsugi Teacup"
+            ],
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Legion",
@@ -482,18 +757,44 @@
                 0
             ],
             "AntiFacecampPermitted": false,
-            "KillerIndvPerkBans": [],
+            "KillerIndvPerkBans": [
+                "150"
+            ],
             "KillerComboPerkBans": [],
-            "SurvivorIndvPerkBans": [],
+            "SurvivorIndvPerkBans": [
+                "1",
+                "13",
+                "21",
+                "34",
+                "36",
+                "38",
+                "39",
+                "44",
+                "57",
+                "76",
+                "112",
+                "121"
+            ],
             "SurvivorComboPerkBans": [],
             "SurvivorWhitelistedPerks": [],
             "SurvivorWhitelistedComboPerks": [],
             "KillerWhitelistedPerks": [],
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
-            "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "IndividualAddonBans": [
+                "Stolen Sketch Book",
+                "Stylish Sunglasses",
+                "Stab Wounds Study"
+            ],
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Plague",
@@ -509,16 +810,34 @@
             "AntiFacecampPermitted": false,
             "KillerIndvPerkBans": [],
             "KillerComboPerkBans": [],
-            "SurvivorIndvPerkBans": [],
+            "SurvivorIndvPerkBans": [
+                "13",
+                "34",
+                "36",
+                "38",
+                "76",
+                "121"
+            ],
             "SurvivorComboPerkBans": [],
             "SurvivorWhitelistedPerks": [],
             "SurvivorWhitelistedComboPerks": [],
             "KillerWhitelistedPerks": [],
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
-            "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "IndividualAddonBans": [
+                "Olibanum Incense",
+                "Iridescent Seal",
+                "Black Incense"
+            ],
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Ghost Face",
@@ -534,16 +853,43 @@
             "AntiFacecampPermitted": false,
             "KillerIndvPerkBans": [],
             "KillerComboPerkBans": [],
-            "SurvivorIndvPerkBans": [],
+            "SurvivorIndvPerkBans": [
+                "1",
+                "13",
+                "21",
+                "34",
+                "36",
+                "38",
+                "39",
+                "44",
+                "57",
+                "76",
+                "92",
+                "112",
+                "121",
+                "85",
+                "111"
+            ],
             "SurvivorComboPerkBans": [],
             "SurvivorWhitelistedPerks": [],
             "SurvivorWhitelistedComboPerks": [],
             "KillerWhitelistedPerks": [],
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
-            "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "IndividualAddonBans": [
+                "Olsen's Address Book",
+                "Driver's License",
+                "Outdoor Security Camera"
+            ],
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Demogorgon",
@@ -557,18 +903,41 @@
                 0
             ],
             "AntiFacecampPermitted": false,
-            "KillerIndvPerkBans": [],
+            "KillerIndvPerkBans": [
+                "150"
+            ],
             "KillerComboPerkBans": [],
-            "SurvivorIndvPerkBans": [],
+            "SurvivorIndvPerkBans": [
+                "13",
+                "21",
+                "34",
+                "36",
+                "38",
+                "39",
+                "44",
+                "57",
+                "76",
+                "112",
+                "121"
+            ],
             "SurvivorComboPerkBans": [],
             "SurvivorWhitelistedPerks": [],
             "SurvivorWhitelistedComboPerks": [],
             "KillerWhitelistedPerks": [],
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
-            "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "IndividualAddonBans": [
+                "Leprose Lichen"
+            ],
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Oni",
@@ -584,16 +953,37 @@
             "AntiFacecampPermitted": false,
             "KillerIndvPerkBans": [],
             "KillerComboPerkBans": [],
-            "SurvivorIndvPerkBans": [],
+            "SurvivorIndvPerkBans": [
+                "13",
+                "21",
+                "34",
+                "36",
+                "38",
+                "39",
+                "44",
+                "57",
+                "76",
+                "92",
+                "121"
+            ],
             "SurvivorComboPerkBans": [],
             "SurvivorWhitelistedPerks": [],
             "SurvivorWhitelistedComboPerks": [],
             "KillerWhitelistedPerks": [],
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
-            "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "IndividualAddonBans": [
+                "Renjiro's Bloody Glove"
+            ],
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Deathslinger",
@@ -609,16 +999,38 @@
             "AntiFacecampPermitted": false,
             "KillerIndvPerkBans": [],
             "KillerComboPerkBans": [],
-            "SurvivorIndvPerkBans": [],
+            "SurvivorIndvPerkBans": [
+                "13",
+                "21",
+                "34",
+                "36",
+                "38",
+                "39",
+                "44",
+                "57",
+                "76",
+                "92",
+                "112",
+                "121"
+            ],
             "SurvivorComboPerkBans": [],
             "SurvivorWhitelistedPerks": [],
             "SurvivorWhitelistedComboPerks": [],
             "KillerWhitelistedPerks": [],
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
-            "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "IndividualAddonBans": [
+                "Iridescent Coin"
+            ],
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Executioner",
@@ -634,16 +1046,39 @@
             "AntiFacecampPermitted": false,
             "KillerIndvPerkBans": [],
             "KillerComboPerkBans": [],
-            "SurvivorIndvPerkBans": [],
+            "SurvivorIndvPerkBans": [
+                "1",
+                "13",
+                "21",
+                "34",
+                "36",
+                "38",
+                "39",
+                "44",
+                "57",
+                "76",
+                "92",
+                "112",
+                "121"
+            ],
             "SurvivorComboPerkBans": [],
             "SurvivorWhitelistedPerks": [],
             "SurvivorWhitelistedComboPerks": [],
             "KillerWhitelistedPerks": [],
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
-            "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "IndividualAddonBans": [
+                "Iridescent Seal of Metatron"
+            ],
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Blight",
@@ -657,7 +1092,13 @@
                 0
             ],
             "AntiFacecampPermitted": false,
-            "KillerIndvPerkBans": [],
+            "KillerIndvPerkBans": [
+                "150",
+                "132",
+                "155",
+                "204",
+                "220"
+            ],
             "KillerComboPerkBans": [],
             "SurvivorIndvPerkBans": [],
             "SurvivorComboPerkBans": [],
@@ -666,9 +1107,22 @@
             "KillerWhitelistedPerks": [],
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
-            "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "IndividualAddonBans": [
+                "Compound Twenty-One",
+                "Adrenaline Vial",
+                "Alchemist's Ring",
+                "Iridescent Blight Tag",
+                "Compound Thirty-Three"
+            ],
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Twins",
@@ -692,8 +1146,15 @@
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
             "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Trickster",
@@ -709,16 +1170,40 @@
             "AntiFacecampPermitted": false,
             "KillerIndvPerkBans": [],
             "KillerComboPerkBans": [],
-            "SurvivorIndvPerkBans": [],
+            "SurvivorIndvPerkBans": [
+                "13",
+                "21",
+                "34",
+                "36",
+                "38",
+                "39",
+                "44",
+                "57",
+                "76",
+                "92",
+                "112",
+                "121"
+            ],
             "SurvivorComboPerkBans": [],
             "SurvivorWhitelistedPerks": [],
             "SurvivorWhitelistedComboPerks": [],
             "KillerWhitelistedPerks": [],
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
-            "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "IndividualAddonBans": [
+                "Diamond Cufflinks",
+                "Iridescent Photocard",
+                "Death Throes Compilation"
+            ],
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Nemesis",
@@ -732,18 +1217,46 @@
                 0
             ],
             "AntiFacecampPermitted": false,
-            "KillerIndvPerkBans": [],
+            "KillerIndvPerkBans": [
+                "150"
+            ],
             "KillerComboPerkBans": [],
-            "SurvivorIndvPerkBans": [],
+            "SurvivorIndvPerkBans": [
+                "1",
+                "13",
+                "21",
+                "34",
+                "36",
+                "38",
+                "39",
+                "44",
+                "47",
+                "57",
+                "76",
+                "92",
+                "112",
+                "121"
+            ],
             "SurvivorComboPerkBans": [],
             "SurvivorWhitelistedPerks": [],
             "SurvivorWhitelistedComboPerks": [],
             "KillerWhitelistedPerks": [],
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
-            "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "IndividualAddonBans": [
+                "S.T.A.R.S. Field Combat Manual",
+                "Jill's Sandwich",
+                "Iridescent Umbrella Badge"
+            ],
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Cenobite",
@@ -757,18 +1270,46 @@
                 0
             ],
             "AntiFacecampPermitted": false,
-            "KillerIndvPerkBans": [],
+            "KillerIndvPerkBans": [
+                "150"
+            ],
             "KillerComboPerkBans": [],
-            "SurvivorIndvPerkBans": [],
+            "SurvivorIndvPerkBans": [
+                "1",
+                "13",
+                "21",
+                "34",
+                "36",
+                "38",
+                "39",
+                "44",
+                "57",
+                "76",
+                "92",
+                "101",
+                "112",
+                "121"
+            ],
             "SurvivorComboPerkBans": [],
             "SurvivorWhitelistedPerks": [],
             "SurvivorWhitelistedComboPerks": [],
             "KillerWhitelistedPerks": [],
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
-            "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "IndividualAddonBans": [
+                "Greasy Black Lens",
+                "Iridescent Lament Configuration",
+                "Engineer's Fang"
+            ],
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Artist",
@@ -782,18 +1323,44 @@
                 0
             ],
             "AntiFacecampPermitted": false,
-            "KillerIndvPerkBans": [],
+            "KillerIndvPerkBans": [
+                "150"
+            ],
             "KillerComboPerkBans": [],
-            "SurvivorIndvPerkBans": [],
+            "SurvivorIndvPerkBans": [
+                "1",
+                "13",
+                "21",
+                "34",
+                "36",
+                "38",
+                "39",
+                "44",
+                "57",
+                "76",
+                "92",
+                "112",
+                "121"
+            ],
             "SurvivorComboPerkBans": [],
             "SurvivorWhitelistedPerks": [],
             "SurvivorWhitelistedComboPerks": [],
             "KillerWhitelistedPerks": [],
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
-            "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "IndividualAddonBans": [
+                "Matias' Baby Shoes",
+                "Garden of Rot"
+            ],
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Onryo",
@@ -807,18 +1374,44 @@
                 0
             ],
             "AntiFacecampPermitted": false,
-            "KillerIndvPerkBans": [],
+            "KillerIndvPerkBans": [
+                "150"
+            ],
             "KillerComboPerkBans": [],
-            "SurvivorIndvPerkBans": [],
+            "SurvivorIndvPerkBans": [
+                "13",
+                "21",
+                "34",
+                "36",
+                "38",
+                "39",
+                "44",
+                "57",
+                "76",
+                "85",
+                "92",
+                "111",
+                "112",
+                "121"
+            ],
             "SurvivorComboPerkBans": [],
             "SurvivorWhitelistedPerks": [],
             "SurvivorWhitelistedComboPerks": [],
             "KillerWhitelistedPerks": [],
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
-            "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "IndividualAddonBans": [
+                "Remote Control"
+            ],
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Dredge",
@@ -832,18 +1425,45 @@
                 0
             ],
             "AntiFacecampPermitted": false,
-            "KillerIndvPerkBans": [],
+            "KillerIndvPerkBans": [
+                "150"
+            ],
             "KillerComboPerkBans": [],
-            "SurvivorIndvPerkBans": [],
+            "SurvivorIndvPerkBans": [
+                "13",
+                "21",
+                "34",
+                "36",
+                "38",
+                "39",
+                "44",
+                "57",
+                "76",
+                "85",
+                "111",
+                "112",
+                "121"
+            ],
             "SurvivorComboPerkBans": [],
             "SurvivorWhitelistedPerks": [],
             "SurvivorWhitelistedComboPerks": [],
             "KillerWhitelistedPerks": [],
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
-            "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "IndividualAddonBans": [
+                "Worry Stone",
+                "Lavalier Microphone",
+                "Iridescent Wooden Plank"
+            ],
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Mastermind",
@@ -857,18 +1477,41 @@
                 0
             ],
             "AntiFacecampPermitted": false,
-            "KillerIndvPerkBans": [],
+            "KillerIndvPerkBans": [
+                "150"
+            ],
             "KillerComboPerkBans": [],
-            "SurvivorIndvPerkBans": [],
+            "SurvivorIndvPerkBans": [
+                "21",
+                "34",
+                "38",
+                "39",
+                "44",
+                "57",
+                "76",
+                "112",
+                "121"
+            ],
             "SurvivorComboPerkBans": [],
             "SurvivorWhitelistedPerks": [],
             "SurvivorWhitelistedComboPerks": [],
             "KillerWhitelistedPerks": [],
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
-            "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "IndividualAddonBans": [
+                "Helicopter Stick",
+                "Uroboros Virus",
+                "Iridescent Uroboros Vial"
+            ],
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Knight",
@@ -882,18 +1525,42 @@
                 0
             ],
             "AntiFacecampPermitted": false,
-            "KillerIndvPerkBans": [],
+            "KillerIndvPerkBans": [
+                "150"
+            ],
             "KillerComboPerkBans": [],
-            "SurvivorIndvPerkBans": [],
+            "SurvivorIndvPerkBans": [
+                "1",
+                "13",
+                "21",
+                "34",
+                "38",
+                "39",
+                "44",
+                "57",
+                "76",
+                "112",
+                "121"
+            ],
             "SurvivorComboPerkBans": [],
             "SurvivorWhitelistedPerks": [],
             "SurvivorWhitelistedComboPerks": [],
             "KillerWhitelistedPerks": [],
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
-            "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "IndividualAddonBans": [
+                "Flint and Steel",
+                "Knight's Contract"
+            ],
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Skull Merchant",
@@ -917,8 +1584,15 @@
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
             "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Singularity",
@@ -932,18 +1606,44 @@
                 0
             ],
             "AntiFacecampPermitted": false,
-            "KillerIndvPerkBans": [],
+            "KillerIndvPerkBans": [
+                "150"
+            ],
             "KillerComboPerkBans": [],
-            "SurvivorIndvPerkBans": [],
+            "SurvivorIndvPerkBans": [
+                "13",
+                "21",
+                "34",
+                "36",
+                "38",
+                "39",
+                "44",
+                "57",
+                "76",
+                "112",
+                "121"
+            ],
             "SurvivorComboPerkBans": [],
             "SurvivorWhitelistedPerks": [],
             "SurvivorWhitelistedComboPerks": [],
             "KillerWhitelistedPerks": [],
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
-            "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "IndividualAddonBans": [
+                "Diagnostic Tool (Construction)",
+                "Crew Manifest",
+                "Iridescent Crystal Shard",
+                "Denied Requisition Form"
+            ],
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         },
         {
             "Name": "The Xenomorph",
@@ -967,8 +1667,15 @@
             "KillerWhitelistedComboPerks": [],
             "AddonTiersBanned": [],
             "IndividualAddonBans": [],
-            "SurvivorOfferings": [],
-            "KillerOfferings": []
+            "SurvivorOfferings": [
+                0,
+                2,
+                5,
+                6
+            ],
+            "KillerOfferings": [
+                5
+            ]
         }
     ]
 }

--- a/public/scripts/balance-checker.js
+++ b/public/scripts/balance-checker.js
@@ -351,9 +351,9 @@ function LoadImportEvents() {
         var exportData = JSON.stringify(CreateStatusObject());
 
         // Ask user if they'd like to copy to clipboard. If yes, copy to clipboard. If no, return.
-        if (!confirm("Would you like to copy your build data to your clipboard?")) {
-            return;
-        }
+        // if (!confirm("Would you like to copy your build data to your clipboard?")) {
+        //     return;
+        // }
 
         // Copy exportData to clipboard
         navigator.clipboard.writeText(exportData);

--- a/public/scripts/balance-checker.js
+++ b/public/scripts/balance-checker.js
@@ -255,9 +255,111 @@ function LoadButtonEvents() {
 
     LoadPerkSelectionEvents();
 
+    LoadImportEvents();
+
     LoadPerkSearchEvents();
 
     LoadRoomEvents();
+}
+
+function LoadImportEvents() {
+    let importButton = document.getElementById("import-button");
+    let exportButton = document.getElementById("export-button");
+
+    importButton.addEventListener("click", function() {
+        let importData = prompt("Please enter your build data here.\n\nThis data can be found by clicking the 'Export' button. Please note that improper formatting may result in unexpected behavior or loss of builds!");
+
+        if (importData == null) {
+            return;
+        }
+
+        try {
+            // Check if importData.SurvivorPerks is a valid array
+            let importDataObj = JSON.parse(importData);
+
+            if (importDataObj.SurvivorPerks == undefined) {
+                throw "Invalid import data. SurvivorPerks is undefined.";
+            }
+            if (importDataObj.SurvivorPerks.length != 4) {
+                throw "Invalid import data. SurvivorPerks length is not 4.";
+            }
+
+            for (var i = 0; i < importDataObj.SurvivorPerks.length; i++) {
+                let currentSurvivor = importDataObj.SurvivorPerks[i];
+
+                if (currentSurvivor.length != 4) {
+                    throw "Invalid import data. SurvivorPerks length is not 4.";
+                }
+
+                for (var j = 0; j < currentSurvivor.length; j++) {
+                    let currentPerk = currentSurvivor[j];
+
+                    if (currentPerk != null) {
+                        if (currentPerk.id == undefined) {
+                            throw "Invalid import data. Perk ID is undefined.";
+                        }
+                        if (currentPerk.name == undefined) {
+                            throw "Invalid import data. Perk name is undefined.";
+                        }
+                        if (currentPerk.icon == undefined) {
+                            throw "Invalid import data. Perk icon is undefined.";
+                        }
+                    }
+                }
+            }
+
+            // Is custom balancing enabled?
+            if (importDataObj.customBalanceOverride == undefined) {
+                throw "Invalid import data. Custom balancing is undefined.";
+            }
+
+            if (importDataObj.customBalanceOverride) {
+                // Check if current balancing is valid
+                let currentBalance = importDataObj.currentBalancing;
+                if (!ValidateCustomBalancing(currentBalance)) {
+                    throw "Invalid import data. Current balancing is invalid.";
+                }
+            }
+
+            // Is there a valid balancing index?
+            if (importDataObj.currentBalancingIndex == undefined) {
+                throw "Invalid import data. Current balancing index is undefined.";
+            }
+
+            // Is there a valid selected killer?
+            if (importDataObj.selectedKiller == undefined) {
+                throw "Invalid import data. Selected killer is undefined.";
+            }
+
+            // If all checks pass, set the data
+            SurvivorPerks = importDataObj.SurvivorPerks;
+            currentBalancingIndex = importDataObj.currentBalancingIndex;
+            selectedKiller = importDataObj.selectedKiller;
+            customBalanceOverride = importDataObj.customBalanceOverride;
+            currentBalancing = importDataObj.currentBalancing;
+
+            // Update UI
+            UpdatePerkUI();
+            UpdateBalancingDropdown();
+            CheckForBalancingErrors();
+        } catch (error) {
+            GenerateAlertModal("Error", `An error occurred while importing your builds. Please ensure that the data is in the correct format.\n\nError: ${error}`);
+        }
+    });
+
+    exportButton.addEventListener("click", function() {
+        var exportData = JSON.stringify(CreateStatusObject());
+
+        // Ask user if they'd like to copy to clipboard. If yes, copy to clipboard. If no, return.
+        if (!confirm("Would you like to copy your build data to your clipboard?")) {
+            return;
+        }
+
+        // Copy exportData to clipboard
+        navigator.clipboard.writeText(exportData);
+
+        GenerateAlertModal("Export Successful", "Your builds data has been copied to your clipboard!");
+    });
 }
 
 function LoadRoomEvents() {

--- a/public/scripts/balance-checker.js
+++ b/public/scripts/balance-checker.js
@@ -22,6 +22,11 @@ var BalancePresets = [
         Name: "Dead by Daylight League (DBDL)",
         Path: "BalancingPresets/DBDL.json",
         Balancing: {}
+    },
+    {
+        Name: "Champions of the Fog (COTF)",
+        Path: "BalancingPresets/COTF.json",
+        Balancing: {}
     }
 ]
 var currentBalancingIndex = 0;

--- a/public/scripts/balance-checker.js
+++ b/public/scripts/balance-checker.js
@@ -1304,6 +1304,7 @@ function UpdateErrorUI() {
     var errorListContainer = document.getElementById("error-list-container");
     errorListContainer.innerHTML = "";
 
+    let ErrorElementList = [];
     for (var i = 0; i < MasterErrorList.length; i++) {
         let currentError = MasterErrorList[i];
 
@@ -1330,7 +1331,24 @@ function UpdateErrorUI() {
         errorContainer.appendChild(errorHeaderContainer);
         errorContainer.appendChild(errorDescription);
 
-        errorListContainer.appendChild(errorContainer);
+        ErrorElementList.push(errorContainer);
+    }
+
+    // Go through error list and add to container with a delay of 100ms in between each error.
+    let totalTime = 0;
+    for (var i = 0; i < ErrorElementList.length; i++) {
+        let currentError = ErrorElementList[i];
+
+        let timerMS = 150 * i;
+
+        totalTime += 150;
+        if (totalTime > 5000) {
+            timerMS = 0;
+        }
+
+        setTimeout(function() {
+            errorListContainer.appendChild(currentError);
+        }, timerMS);
     }
 
     var errorPanelTitle = document.getElementById("error-panel-title");

--- a/public/scripts/balance-checker.js
+++ b/public/scripts/balance-checker.js
@@ -810,7 +810,7 @@ function CheckForDuplicates(survIndex, build) {
                 ErrorLog.push(
                     GenerateErrorObject(
                         "Duplicate Perk",
-                        `Perk <b>${currentPerk["name"]}</b> is duplicated in <b>Survivor #${survIndex}</b>'s build.`,
+                        `Perk <b>${currentPerk["name"]}</b> is duplicated in <b>Survivor #${survIndex+1}</b>'s build.`,
                         console.trace(),
                         "iconography/CriticalError.png"
                     )
@@ -1002,7 +1002,7 @@ function ComboIsBannedInOverride(build, override, survivorIndex) {
                 ErrorList.push(
                     GenerateErrorObject(
                         "Banned Combo",
-                        `Combo <b>${PrintCombo(currentCombo)}</b> is banned against <b>${override.Name}</b>. It is present in <b>Survivor #${survivorIndex}</b>'s build.`,
+                        `Combo <b>${PrintCombo(currentCombo)}</b> is banned against <b>${override.Name}</b>. It is present in <b>Survivor #${survivorIndex+1}</b>'s build.`,
                         console.trace(),
                         "iconography/Error.png"
                     )
@@ -1043,7 +1043,7 @@ function ComboIsBannedInOverride(build, override, survivorIndex) {
                     ErrorList.push(
                         GenerateErrorObject(
                             "Banned Combo",
-                            `Combo <b>${PrintCombo(currentCombo)}</b> is banned in <b>${currentTier.Name}</b> Tier Balancing. It is present in <b>Survivor #${survivorIndex}</b>'s build.`,
+                            `Combo <b>${PrintCombo(currentCombo)}</b> is banned in <b>${currentTier.Name}</b> Tier Balancing. It is present in <b>Survivor #${survivorIndex+1}</b>'s build.`,
                             console.trace(),
                             "iconography/Error.png"
                         )
@@ -1110,7 +1110,7 @@ function IndividualIsBannedInOverride(build, override, survivorIndex) {
                 ErrorList.push(
                     GenerateErrorObject(
                         "Banned Perk",
-                        `Perk <b>${currentPerk["name"]}</b> is banned against <b>${override.Name}</b>. It is present in <b>Survivor #${survivorIndex}</b>'s build.`,
+                        `Perk <b>${currentPerk["name"]}</b> is banned against <b>${override.Name}</b>. It is present in <b>Survivor #${survivorIndex+1}</b>'s build.`,
                         console.trace(),
                         "iconography/Error.png"
                     )
@@ -1161,7 +1161,7 @@ function IndividualIsBannedInOverride(build, override, survivorIndex) {
                     ErrorList.push(
                         GenerateErrorObject(
                             "Banned Perk",
-                            `Perk <b>${currentPerk["name"]}</b> is banned in <b>${currentTier.Name}</b> Tier Balancing. It is present in <b>Survivor #${survivorIndex}</b>'s build.`,
+                            `Perk <b>${currentPerk["name"]}</b> is banned in <b>${currentTier.Name}</b> Tier Balancing. It is present in <b>Survivor #${survivorIndex+1}</b>'s build.`,
                             console.trace(),
                             "iconography/Error.png"
                         )

--- a/public/stylesheets/balance-checker.css
+++ b/public/stylesheets/balance-checker.css
@@ -526,7 +526,7 @@ body {
 
     margin-right: 1px;
 
-    animation: fade-in-blur 0.5s ease-in-out;
+    animation: scale-in 0.5s ease-in-out;
 }
 
 .error-header-container {

--- a/public/stylesheets/balance-checker.css
+++ b/public/stylesheets/balance-checker.css
@@ -796,6 +796,55 @@ body {
     height: 100%;
 }
 
+#import-export-button-container {
+    width: 50%;
+    display: flex;
+    margin: 5px;
+    gap: 5px;
+    padding: 5px;
+
+    margin: auto;
+
+    align-items: center;
+    justify-content: center;
+}
+
+#import-export-button-container button {
+    width: 50%;
+    height: 100%;
+
+    background-color: #ffffff00;
+    color: #ffffff;
+    font-weight: 700;
+
+    padding: 5px;
+
+    border-radius: 10px;
+    border-color: #ffffff;
+    border-width: 2px;
+    border-style: solid;
+
+    transition: all 0.2s ease-in-out;
+
+    cursor: pointer;
+}
+
+#import-export-button-container button:hover {
+    background-color: #ffffff20;
+
+    filter:drop-shadow(0px 0px 4px #000000);
+    
+    padding: 7px;
+}
+
+#import-export-button-container button:active {
+    background-color: #ffffff10;
+
+    filter:drop-shadow(0px 0px 2px #000000);
+    
+    padding: 6px;
+}
+
 /* Intro animation for settings menu */
 @keyframes intro-blur {
     from {backdrop-filter: blur(0px);}

--- a/views/balance-checker.pug
+++ b/views/balance-checker.pug
@@ -125,6 +125,9 @@ html
                             img(src="public/Perks/Survivors/Hope.png")
                         div.perk-slot
                             img(src="public/Perks/Survivors/Kinship.png")
+                div#import-export-button-container
+                    button#import-button Import Builds
+                    button#export-button Export Builds
             div#errors-window
                 h1#error-panel-title Errors
                 div#error-list-container(class="override-scrollbar")
@@ -177,6 +180,16 @@ html
                     p Made by Kyle Starr (v1.0)
                     div#settings-button-container
                         button#settings-cancel-button Close
+        div#import-container()
+            div#import-blur(class="background-blur")
+                div#import-menu
+                    h1#import-title Import Builds
+                    p#build-import-instructions Please paste your build JSON below. If it is valid, it will be imported into your current build.
+                    textarea#build-import-textarea(class="override-scrollbar", placeholder="Enter Build JSON...", rows="15")
+                    br
+                    div#import-button-container
+                        button#build-import-button Import
+                        button#build-import-cancel-button Cancel
         div#alert-container(hidden="hidden")
             div#alert-blur(class="background-blur")
                 div#alert-menu


### PR DESCRIPTION
CHANGES:
- Adjusted the error detection to show survivor build numbers from 1-4 instead of 0-3.
- Added an Import/Export button to the builds menu. Exporting automatically copies the build status to your clipboard as JSON. Importing opens a prompt directing you to paste in data, if it isn't correct it _should_ stop you. If it passes though, unintended behaviour may occur. There is a warning for this.
- Added COTF balancing, and as it was my first experience with COTF balancing I went in a small child and came out a man that has been through trials of war.