### PR TITLE
- Fixed killer select UI not updating on import

### DIFF
--- a/public/scripts/balance-checker.js
+++ b/public/scripts/balance-checker.js
@@ -347,6 +347,7 @@ function LoadImportEvents() {
             UpdatePerkUI();
             UpdateBalancingDropdown();
             CheckForBalancingErrors();
+            UpdateKillerSelectionUI();
         } catch (error) {
             GenerateAlertModal("Error", `An error occurred while importing your builds. Please ensure that the data is in the correct format.\n\nError: ${error}`);
         }


### PR DESCRIPTION
The killer selection UI was not updating appropriately upon import. This was due to the `UpdateKillerSelectionUI()` function not being called post-import, so while the selected killer _was_ switching it wasn't properly displaying in the UI.