### PR TITLE
New balancing select

### DIFF
--- a/public/scripts/checker/checker-events.js
+++ b/public/scripts/checker/checker-events.js
@@ -20,7 +20,7 @@ function SetBalancingSelectButtonEvents() {
         let optionsContainer = document.getElementById("balancing-select-options-container");
         let balanceOptions = optionsContainer.children;
 
-        PopulateBalancingSelectMenuFromSearch(searchQuery);
+        PopulateBalancingSelectMenuFromSearch(searchQuery.toLowerCase());
     });
 
     openButton.addEventListener("click", function() {

--- a/public/scripts/checker/checker-events.js
+++ b/public/scripts/checker/checker-events.js
@@ -26,6 +26,12 @@ function SetBalancingSelectButtonEvents() {
     openButton.addEventListener("click", function() {
         balancingSelectContainer.hidden = false;
 
+        let balancingSelectMenu = document.getElementById("balancing-select-menu");
+        delete balancingSelectMenu.dataset.proposedPresetID;
+
+        let closeButton = document.getElementById("balancing-select-close-button");
+        closeButton.innerText = "Cancel";
+
         let balanceSubtitleText = document.getElementById("balancing-select-subtitle");
         const currentBalanceName = GetBalancePresetByID(currentBalancingIndex)["Name"];
 

--- a/public/scripts/checker/checker-events.js
+++ b/public/scripts/checker/checker-events.js
@@ -857,10 +857,13 @@ function ApplyBalancingOptionEvents(optionNode, presetIndex) {
         3. Add the "proposed-league-selection" class to this option.
         */
         let balancingSelectMenu = document.getElementById("balancing-select-menu");
-        
+        let closeButton = document.getElementById("balancing-select-close-button");
+
         if (optionNode.dataset.balancePresetID == balancingSelectMenu.dataset.proposedPresetID) {
             delete balancingSelectMenu.dataset.proposedPresetID;
             optionNode.classList.remove("proposed-league-selection");
+            
+            closeButton.innerText = "Cancel";
             return;
         }
 
@@ -872,6 +875,8 @@ function ApplyBalancingOptionEvents(optionNode, presetIndex) {
         balancingSelectMenu.dataset.proposedPresetID = optionNode.dataset.balancePresetID;
 
         optionNode.classList.add("proposed-league-selection");
+
+        closeButton.innerText = "Confirm Changes";
     });
 
     return optionNode;

--- a/public/scripts/checker/checker-main.js
+++ b/public/scripts/checker/checker-main.js
@@ -67,7 +67,7 @@ function main() {
     LoadButtonEvents();
 
     // Update balancing dropdown
-    UpdateBalancingDropdown();
+    SetBalancingSelectButtonEvents();
 
     // Set current balancing
 

--- a/public/scripts/checker/checker-main.js
+++ b/public/scripts/checker/checker-main.js
@@ -4,10 +4,6 @@ function main() {
     // Get config
     GetConfig();
 
-    if (Config.multiplayerEnabled) {
-        socket = io();
-    }
-
     // Initialize Survivor Perks
     for (var i = 0; i < SurvivorPerks.length; i++) {
         SurvivorPerks[i] = [
@@ -51,9 +47,6 @@ function main() {
 
     UpdateRoleSwapIcon();
 
-    // Load data
-    GetBalancings();
-
     // Update Perk Page
     UpdatePerkUI();
 
@@ -74,6 +67,15 @@ function main() {
     // Sets balancing to either local storage or default, in this case we're doing local storage since it's default balancing.
     currentBalancingIndex = 0;
     if(localStorage.getItem("currentBalancingIndex")) currentBalancingIndex = parseInt(localStorage.getItem("currentBalancingIndex"));
+
+    TryLoadBalanceProfileFromPresetID(currentBalancingIndex,
+        function() {
+            TrySetCurrentBalancing();
+        },
+        function() {
+            console.error("Could not set balancing!");
+        }
+    );
 
     let loadDefaultBalance = true;
     // Load custom balancing if enabled
@@ -108,7 +110,8 @@ function main() {
             
             localStorage.setItem("currentBalancingIndex", currentBalancingIndex);
         }
-        currentBalancing = GetBalancePresetByID(currentBalancingIndex)["Balancing"];
+        //currentBalancing = GetBalancePresetByID(currentBalancingIndex)["Balancing"];
+        TrySetCurrentBalancing();
     }
 
     // Update Balancing Selection UI
@@ -129,12 +132,6 @@ function main() {
     // Update the custom balance text area to show the current custom balancing
     if (customBalanceOverride) {
         document.getElementById("custom-balance-select").value = JSON.stringify(currentBalancing, null, 4);
-        
-        // Hide the balancing select dropdown
-        document.getElementById("balancing-select").hidden = true;
-        document.getElementById("balance-mode-label").hidden = true;
-
-        document.getElementById("balance-type-box").style.display = "none";
 
         // Show the custom balancing text area
         document.getElementById("custom-balance-select").hidden = false;

--- a/public/scripts/checker/checker-utility.js
+++ b/public/scripts/checker/checker-utility.js
@@ -1322,9 +1322,10 @@ function GenerateImageFromButtonPress() {
  * Returns true or false depending on whether or not the option should be visible when searched with query.
  * @param {Number} presetID 
  * @param {String} query 
+ * @param {Boolean} showIfProposed Whether to ignore queries and return true if the current preset ID is the same as the proposed one.
  * @returns {Boolean}
  */
-function GetBalanceSelectOptionVisibilityInSearch(presetID, query) {
+function GetBalanceSelectOptionVisibilityInSearch(presetID, query, showIfProposed = true) {
     /**
      * Does the name include the query? True.
      * Loop through every alias.
@@ -1338,10 +1339,20 @@ function GetBalanceSelectOptionVisibilityInSearch(presetID, query) {
 
     if (currentPreset == undefined) { return false; }
 
-    const name = currentPreset["Name"];
+    const name = currentPreset["Name"].toLowerCase();
     const aliases = currentPreset["Aliases"];
     let splitAliases = undefined;
 
+    if (showIfProposed) {
+        let currentBalancingMenu = document.getElementById("balancing-select-menu");
+        let proposedID = parseInt(currentBalancingMenu.dataset.proposedPresetID);
+
+        if (!isNaN(proposedID)) {
+            if (proposedID === presetID) {
+                return true;
+            }
+        }
+    }
     
     if (aliases != undefined) {
         try {
@@ -1357,7 +1368,7 @@ function GetBalanceSelectOptionVisibilityInSearch(presetID, query) {
 
     if (splitAliases != undefined) {
         for (let i = 0; i < splitAliases.length; i++) {
-            const alias = splitAliases[i];
+            const alias = splitAliases[i].toLowerCase();
 
             if (alias.includes(query)) {
                 return true;

--- a/public/scripts/checker/checker-utility.js
+++ b/public/scripts/checker/checker-utility.js
@@ -1317,3 +1317,61 @@ function GenerateImageFromButtonPress() {
         ExportData: exportData
     }));
 }
+
+/**
+ * Returns true or false depending on whether or not the option should be visible when searched with query.
+ * @param {Number} presetID 
+ * @param {String} query 
+ * @returns {Boolean}
+ */
+function GetBalanceSelectOptionVisibilityInSearch(presetID, query) {
+    /**
+     * Does the name include the query? True.
+     * Loop through every alias.
+     *      Does this alias include the query? True.
+     * Are we searching for specifically an ID? (isNumber?)
+     * 
+     * False.
+     */
+
+    const currentPreset = GetBalancePresetByID(presetID);
+
+    if (currentPreset == undefined) { return false; }
+
+    const name = currentPreset["Name"];
+    const aliases = currentPreset["Aliases"];
+    let splitAliases = undefined;
+
+    
+    if (aliases != undefined) {
+        try {
+            splitAliases = aliases.split(",");
+        } catch {
+            console.error("Aliases value was undefined! This has been handled appropriately!");
+        }
+    }
+
+    if (name.includes(query)) {
+        return true;
+    }
+
+    if (splitAliases != undefined) {
+        for (let i = 0; i < splitAliases.length; i++) {
+            const alias = splitAliases[i];
+
+            if (alias.includes(query)) {
+                return true;
+            }
+        }
+    }
+
+    if (!isNaN(query)) { // If the query is numeric
+        const queryNum = Math.round(parseFloat(query));
+
+        if (queryNum == presetID) {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/public/scripts/checker/checker-utility.js
+++ b/public/scripts/checker/checker-utility.js
@@ -1386,3 +1386,47 @@ function GetBalanceSelectOptionVisibilityInSearch(presetID, query, showIfPropose
 
     return false;
 }
+
+/**
+ * Attempts to populate the balancing property of a balance preset from its preset ID.
+ * @param {Number} presetID 
+ * @param {function} success The code that should run once a result has been reached.
+ * @param {function} error The code that should run if this fails.
+ */
+function TryLoadBalanceProfileFromPresetID(presetID, success, error) {
+    let preset = GetBalancePresetByID(presetID);
+
+    if (preset["Balancing"] !== undefined) {
+        success();
+        return;
+    }
+
+    GetBalancingFromPresetID(presetID, function() {
+        success();
+    },
+    function() {
+        error();
+    });
+}
+
+/**
+ * Attempts to set the currentBalancing variable via the currentBalancingIndex.
+ */
+function TrySetCurrentBalancing() {
+    let currentPreset = GetBalancePresetByID(currentBalancingIndex);
+
+    if (currentPreset["Balancing"] === undefined) {
+        console.error(`Balancing is undefined for preset "${currentPreset["Name"]}"!`);
+        TryLoadBalanceProfileFromPresetID(currentBalancing,
+            function() {
+                console.log("Successfully retrieved balancing!")
+            }, function() {
+                console.error("Could not load balance preset resource!");
+            }
+        )
+
+        return;
+    }
+
+    currentBalancing = currentPreset["Balancing"];
+}

--- a/public/stylesheets/balance-checker.css
+++ b/public/stylesheets/balance-checker.css
@@ -8,6 +8,10 @@ body {
     margin: 0;
 }
 
+button {
+    font-family: 'Poppins';
+}
+
 #primary-balance-container {
     display: grid;
     grid-template-columns: 8fr 12fr 55fr 25fr;
@@ -199,6 +203,7 @@ body {
     padding-top: 1px;
 
     border-radius: 17.5px;
+    border: solid white 1px;
 
     top: 50%;
     left: 50%;
@@ -1255,6 +1260,218 @@ body {
     
     margin: 0;
     margin-top: 5px;
+}
+
+#balancing-select-container {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    margin: 0;
+}
+
+#balancing-select-menu {
+    background-color: #2b2452;
+
+    position: relative;
+
+    width: 600px;
+
+    text-align: center;
+    padding: 10px;
+    padding-top: 10px;
+    padding-top: 1px;
+
+    border-radius: 17.5px;
+    border: solid white 1px;
+
+    top: 50%;
+    left: 50%;
+
+    transform: translate(-50%, -50%);
+    transition: all 0.2s ease-in-out;
+}
+
+#balancing-select-title {
+    margin-bottom: 5px;
+}
+
+#balancing-select-subtitle {
+    margin-top: 0px;
+}
+
+#balancing-select-search-input {
+    width: 100%;
+    height: 40px;
+    font-size: 1.1rem;
+    font-weight: 600;
+    text-align: center;
+    background-color: #00000050;
+    border-style: none;
+    color: #e8e8e8;
+
+    border-radius: 7.5px;
+    border: solid white 0px;
+
+    transition: all 0.15s ease-in-out;
+}
+
+#balancing-select-search-input:hover {
+    background-color: #10101040;
+    border-radius: 10px;
+}
+
+#balancing-select-search-input:active {
+    background-color: #20202050;
+}
+
+#balancing-select-search-input::placeholder {
+    font-style: italic;
+    font-weight: 500;
+}
+
+#balancing-select-options-container {
+    max-height: 500px;
+    min-height: 300px;
+
+    background-color: #00000040;
+    
+    margin-top: 5px;
+    margin-bottom: 10px;  
+    
+    border-radius: 7.5px;
+
+    display: flex;
+    flex-flow: row wrap;
+    align-items: start;
+    gap: 5px;
+    padding: 10px 0px 10px 0px;
+    overflow-y: scroll;
+}
+
+.balancing-select-option {
+    width: 100%;
+    max-height: 90px;
+
+    margin: 0px 10px 0px 10px;
+    
+    background-color: #44397f;
+    color: #e8e8e8;
+    
+    border-style: none;
+    border: solid white 1px;
+    border-radius: 2.5px;
+    
+    display: grid;
+    grid-template-columns: 1fr 5fr;
+    
+    overflow: hidden;
+    cursor: pointer;
+
+    transition: all 0.2s ease-in;
+}
+
+.league-selected {
+    border-width: 3px;
+    border-color: #ffd2aa;
+    background-color: #a25a2f;
+}
+
+.league-selected:hover {
+    background-color: #d0733d !important;
+}
+
+.league-selected:active {
+    background-color: #c26b39 !important;
+}
+
+.balancing-select-option:hover {
+    background-color: #5f50b4;
+    border-radius: 3px;
+    padding-left: 25px;
+}
+
+.balancing-select-option:active {
+    background-color: #5749a3;
+    border-radius: 2px;
+    padding-left: 12.5px;
+}
+
+.balancing-select-option-icon {
+    width: 100%;
+    display: flex;
+}
+
+.balancing-select-option-icon img {
+    width: 80%;
+    object-fit: contain;
+}
+
+.balancing-select-option-text-container {
+    text-align: left;
+    
+    display: grid;
+    grid-template-rows: 1fr 1fr;
+}
+
+.balancing-select-option-title {
+    font-weight: 700;
+    font-size: 1.25rem;
+
+    margin-bottom: 0px;
+    margin-top: 10px;
+
+    text-overflow: clip;
+}
+
+.balancing-select-last-updated {
+    font-weight: 500;
+    font-size: 1rem;
+    font-style: italic;
+
+    margin-bottom: 0px;
+    margin-top: 5px;
+
+    opacity: 0.75;
+    
+    text-overflow: clip;
+}
+
+#balancing-select-close-button {
+    width: 100%;
+    height: 100%;
+
+    background-color: #ffffff00;
+    color: #ffffff;
+    font-weight: 700;
+
+    padding: 5px;
+
+    border-radius: 10px;
+    border-color: #ffffff;
+    border-width: 2px;
+    border-style: solid;
+
+    transition: all 0.2s ease-in-out;
+
+    cursor: pointer;
+}
+
+#balancing-select-close-button:hover {
+    background-color: #ffffff20;
+
+    filter:drop-shadow(0px 0px 4px #000000);
+    
+    padding: 7px;
+}
+
+#balancing-select-close-button:active {
+    background-color: #ffffff10;
+
+    filter:drop-shadow(0px 0px 2px #000000);
+    
+    padding: 6px;
 }
 
 /* Intro animation for settings menu */

--- a/public/stylesheets/balance-checker.css
+++ b/public/stylesheets/balance-checker.css
@@ -281,39 +281,6 @@ button {
     text-decoration: underline;
 }
 
-#balancing-select {
-
-    background-color: #ffffff00;
-    color: #ffffff;
-    font-weight: 700;
-
-    margin-left: 5px;
-
-    padding: 5px;
-
-    border-radius: 10px;
-    border-color: #ffffff;
-    border-width: 2px;
-    border-style: solid;
-
-    -moz-appearance: none;
-    -webkit-appearance: none;
-    appearance: none;
-
-    transition: all 0.2s ease-in-out;
-
-    cursor: pointer;
-}
-
-#balancing-select option {
-    color: white;
-    background-color: #16151f;
-    font-weight: 500;
-
-    height: 100%;
-    font-size: 0.9rem;
-}
-
 #main-balance-window {
     text-align: center;
 }
@@ -1230,36 +1197,6 @@ button {
     filter:drop-shadow(0px 0px 2px #000000);
     
     padding: 6px;
-}
-
-#balance-type-box {
-    background-color: #00000040;
-    border-radius: 20px;
-    margin-top: 5px;
-    margin-bottom: 20px;
-
-    display: grid;
-    grid-template-columns: 1fr 4fr;
-    align-items: center;
-}
-
-#balance-type-icon {
-    width: 75%;
-    padding-left: 12.5%;
-    padding-right: 12.5%;
-    margin: 0;
-}
-
-#balance-type-text {
-    font-size: 0.75rem;
-
-    height: 100%;
-
-    padding-top: 9px;
-    padding-right: 15px;
-    
-    margin: 0;
-    margin-top: 5px;
 }
 
 #balancing-select-container {

--- a/public/stylesheets/balance-checker.css
+++ b/public/stylesheets/balance-checker.css
@@ -1345,6 +1345,7 @@ button {
     display: flex;
     flex-flow: row wrap;
     align-items: start;
+    align-content: flex-start;
     gap: 5px;
     padding: 10px 0px 10px 0px;
     overflow-y: scroll;
@@ -1372,17 +1373,17 @@ button {
     transition: all 0.2s ease-in;
 }
 
-.league-selected {
+.proposed-league-selection {
     border-width: 3px;
     border-color: #ffd2aa;
     background-color: #a25a2f;
 }
 
-.league-selected:hover {
+.proposed-league-selection:hover {
     background-color: #d0733d !important;
 }
 
-.league-selected:active {
+.proposed-league-selection:active {
     background-color: #c26b39 !important;
 }
 
@@ -1470,6 +1471,40 @@ button {
     background-color: #ffffff10;
 
     filter:drop-shadow(0px 0px 2px #000000);
+    
+    padding: 6px;
+}
+
+#balancing-select-button {
+    width: 100%;
+    height: 100%;
+    font-size:1rem;
+    background-color: #ffffff00;
+    color: #ffffff;
+    font-weight: 700;
+    padding: 5px;
+    border-radius: 10px;
+    border-color: #ffffff;
+    border-width: 2px;
+    border-style: solid;
+    transition: all 0.2s ease-in-out;
+    cursor: pointer;
+}
+
+#balancing-select-button:hover {
+    background-color: #ffffff20;
+
+    filter:drop-shadow(0px 0px 4px #000000);
+    font-size: 1.04rem;
+    
+    padding: 7px;
+}
+
+#balancing-select-button:active {
+    background-color: #ffffff10;
+
+    filter:drop-shadow(0px 0px 2px #000000);
+    font-size: 1.02rem;
     
     padding: 6px;
 }

--- a/views/balance-checker.pug
+++ b/views/balance-checker.pug
@@ -241,12 +241,8 @@ html
             div#settings-blur(class="background-blur")
                 div#settings-menu
                     h1 Settings Menu
-                    label#balance-mode-label(for="balancing-select") Balancing Mode: 
-                    select#balancing-select
+                    button#balancing-select-button Select a Preset...
                     br
-                    div#balance-type-box
-                        img#balance-type-icon(src="iconography/BalancingTypes/Automated.webp")
-                        p#balance-type-text This balancing is [X]. This means it is/isn't managed by the league associated with it and is/isn't managed by the developers of Balanced by Daylight.
                     label(for="custom-balancing-checkbox") Enable Custom Balancing?
                     input#custom-balancing-checkbox(type="checkbox")
                     br
@@ -271,7 +267,7 @@ html
                     div#settings-button-container
                         button#settings-clear-storage-button Clear Settings
                         button#settings-cancel-button Close
-        div#balancing-select-container()
+        div#balancing-select-container(hidden="hidden")
             div#balancing-select-blur(class="background-blur")
                 div#balancing-select-menu
                     h1#balancing-select-title Balancing Select

--- a/views/balance-checker.pug
+++ b/views/balance-checker.pug
@@ -18,7 +18,7 @@ html
         script(src="/scripts/checker/checker-main.js", type="text/javascript", defer="defer")
 
         meta(name="viewport" content="width=device-width, initial-scale=1.0")
-    body(onload="main()")
+    body(onload="BeginResourceChain()")
         div#primary-balance-container
             div#balance-tabs-container
                 div#role-swap-button(class="tier-selector-button")

--- a/views/balance-checker.pug
+++ b/views/balance-checker.pug
@@ -271,11 +271,56 @@ html
                     div#settings-button-container
                         button#settings-clear-storage-button Clear Settings
                         button#settings-cancel-button Close
-        div#balancing-select-container(hidden="hidden")
+        div#balancing-select-container()
             div#balancing-select-blur(class="background-blur")
                 div#balancing-select-menu
-                    h1#balancing-select-title
-                    p#balancing-select-subtitle
+                    h1#balancing-select-title Balancing Select
+                    p#balancing-select-subtitle Select your desired balancing preset from the options below:
+                    input#balancing-select-search-input(type="search" placeholder="Search for Balancing Presets...")
+                    div#balancing-select-options-container
+                        button.balancing-select-option
+                            div.balancing-select-option-icon
+                                img(src="iconography/BalancingTypes/Automated.webp")
+                            div.balancing-select-option-text-container
+                                p.balancing-select-option-title League Title
+                                p.balancing-select-last-updated Last Updated: 2024-06-22, 11:42:54 a.m.
+                        button.balancing-select-option
+                            div.balancing-select-option-icon
+                                img(src="iconography/BalancingTypes/Automated.webp")
+                            div.balancing-select-option-text-container
+                                p.balancing-select-option-title League Title
+                                p.balancing-select-last-updated Last Updated: 2024-06-22, 11:42:54 a.m.
+                        button.balancing-select-option
+                            div.balancing-select-option-icon
+                                img(src="iconography/BalancingTypes/Automated.webp")
+                            div.balancing-select-option-text-container
+                                p.balancing-select-option-title League Title
+                                p.balancing-select-last-updated Last Updated: 2024-06-22, 11:42:54 a.m.
+                        button.balancing-select-option
+                            div.balancing-select-option-icon
+                                img(src="iconography/BalancingTypes/Automated.webp")
+                            div.balancing-select-option-text-container
+                                p.balancing-select-option-title League Title
+                                p.balancing-select-last-updated Last Updated: 2024-06-22, 11:42:54 a.m.
+                        button.balancing-select-option
+                            div.balancing-select-option-icon
+                                img(src="iconography/BalancingTypes/Automated.webp")
+                            div.balancing-select-option-text-container
+                                p.balancing-select-option-title League Title
+                                p.balancing-select-last-updated Last Updated: 2024-06-22, 11:42:54 a.m.
+                        button.balancing-select-option
+                            div.balancing-select-option-icon
+                                img(src="iconography/BalancingTypes/Automated.webp")
+                            div.balancing-select-option-text-container
+                                p.balancing-select-option-title League Title
+                                p.balancing-select-last-updated Last Updated: 2024-06-22, 11:42:54 a.m.
+                        button.balancing-select-option
+                            div.balancing-select-option-icon
+                                img(src="iconography/BalancingTypes/Automated.webp")
+                            div.balancing-select-option-text-container
+                                p.balancing-select-option-title League Title
+                                p.balancing-select-last-updated Last Updated: 2024-06-22, 11:42:54 a.m.
+                    button#balancing-select-close-button Close
         div#image-gen-container(hidden="hidden")
             div#image-gen-blur(class="background-blur")
                 div#image-gen-menu

--- a/views/balance-checker.pug
+++ b/views/balance-checker.pug
@@ -212,31 +212,7 @@ html
                 div#perk-search-results-module(class="override-scrollbar")
                     div.perk-slot-result
                         img(src="public/Perks/Survivors/Adrenaline.webp")
-                    div.perk-slot-result
-                        img(src="public/Perks/Survivors/Adrenaline.webp")
-                    div.perk-slot-result
-                        img(src="public/Perks/Survivors/Adrenaline.webp")
-                    div.perk-slot-result
-                        img(src="public/Perks/Survivors/Adrenaline.webp")
-                    div.perk-slot-result
-                        img(src="public/Perks/Survivors/Adrenaline.webp")
-                    div.perk-slot-result
-                        img(src="public/Perks/Survivors/Adrenaline.webp")
-                    div.perk-slot-result
-                        img(src="public/Perks/Survivors/Adrenaline.webp")
                 h3#perk-highlight-name Select a Perk...
-        div#room-container(hidden="hidden")
-            div#room-blur(class="background-blur")
-                div#room-menu
-                    h1 Room Menu
-                    h2 Room Code: {ROOM CODE}
-                    p You can share this code with your friends to create builds together!
-                    input#room-code-input(type="text", placeholder="Enter Room Code...")
-                    button#join-room-button Join Room
-                    br
-                    button#leave-room-button Leave Room
-                    br
-                    button#close-room-button Close
         div#settings-container(hidden="hidden")
             div#settings-blur(class="background-blur")
                 div#settings-menu
@@ -274,49 +250,7 @@ html
                     p#balancing-select-subtitle Select your desired balancing preset from the options below:
                     input#balancing-select-search-input(type="search" placeholder="Search for Balancing Presets...")
                     div#balancing-select-options-container
-                        button.balancing-select-option
-                            div.balancing-select-option-icon
-                                img(src="iconography/BalancingTypes/Automated.webp")
-                            div.balancing-select-option-text-container
-                                p.balancing-select-option-title League Title
-                                p.balancing-select-last-updated Last Updated: 2024-06-22, 11:42:54 a.m.
-                        button.balancing-select-option
-                            div.balancing-select-option-icon
-                                img(src="iconography/BalancingTypes/Automated.webp")
-                            div.balancing-select-option-text-container
-                                p.balancing-select-option-title League Title
-                                p.balancing-select-last-updated Last Updated: 2024-06-22, 11:42:54 a.m.
-                        button.balancing-select-option
-                            div.balancing-select-option-icon
-                                img(src="iconography/BalancingTypes/Automated.webp")
-                            div.balancing-select-option-text-container
-                                p.balancing-select-option-title League Title
-                                p.balancing-select-last-updated Last Updated: 2024-06-22, 11:42:54 a.m.
-                        button.balancing-select-option
-                            div.balancing-select-option-icon
-                                img(src="iconography/BalancingTypes/Automated.webp")
-                            div.balancing-select-option-text-container
-                                p.balancing-select-option-title League Title
-                                p.balancing-select-last-updated Last Updated: 2024-06-22, 11:42:54 a.m.
-                        button.balancing-select-option
-                            div.balancing-select-option-icon
-                                img(src="iconography/BalancingTypes/Automated.webp")
-                            div.balancing-select-option-text-container
-                                p.balancing-select-option-title League Title
-                                p.balancing-select-last-updated Last Updated: 2024-06-22, 11:42:54 a.m.
-                        button.balancing-select-option
-                            div.balancing-select-option-icon
-                                img(src="iconography/BalancingTypes/Automated.webp")
-                            div.balancing-select-option-text-container
-                                p.balancing-select-option-title League Title
-                                p.balancing-select-last-updated Last Updated: 2024-06-22, 11:42:54 a.m.
-                        button.balancing-select-option
-                            div.balancing-select-option-icon
-                                img(src="iconography/BalancingTypes/Automated.webp")
-                            div.balancing-select-option-text-container
-                                p.balancing-select-option-title League Title
-                                p.balancing-select-last-updated Last Updated: 2024-06-22, 11:42:54 a.m.
-                    button#balancing-select-close-button Close
+                    button#balancing-select-close-button Cancel
         div#image-gen-container(hidden="hidden")
             div#image-gen-blur(class="background-blur")
                 div#image-gen-menu

--- a/views/balance-checker.pug
+++ b/views/balance-checker.pug
@@ -271,6 +271,11 @@ html
                     div#settings-button-container
                         button#settings-clear-storage-button Clear Settings
                         button#settings-cancel-button Close
+        div#balancing-select-container(hidden="hidden")
+            div#balancing-select-blur(class="background-blur")
+                div#balancing-select-menu
+                    h1#balancing-select-title
+                    p#balancing-select-subtitle
         div#image-gen-container(hidden="hidden")
             div#image-gen-blur(class="background-blur")
                 div#image-gen-menu


### PR DESCRIPTION
This update is what I literally spent my entire day on and contains a rework of how the balancing preset selection is done and contains several key optimizations for those on lower-speed networks (and judging by some of the hits I've experienced in this community - this is most of you). While this full update was done over the course of a few days, much of this has been planned and strategized for a while.

### Added
* There is now a new balancing preset selection menu!
	* There was some internal discussion about how as the site grows and the Autobalancer is taking on more load, the frontend dropdown balancing presets are selected with will be more and more annoying to deal with. Especially if you just want to find that one specific preset out of 20. As a result, this new menu was born. It has some updated functionality and some cool features to make things easy.
	* Clicking on a preset will turn it orange, meaning when you close the menu, that preset will be what is swapped to.
		* Clicking on a preset while it's orange will deselect it.
	* Your currently active preset will not show in the menu, if you'd like to keep the preset without changing, just hit "Cancel" at the bottom without any presets selected (none are orange).
	* Added a search bar to easily search for different leagues. This is focused when the menu is opened, just like perk search!
		* You can search by preset name, the preset's alias(es) (e.g. "OTF" for "Outrun the Fog" or "OhTofu" for "Tofu Scrims" .etc), or the internal numerical ID (most of you won't use this last bit).
		* It instantly makes prior presets disappear.
		* If you have a preset selected, that one will show regardless of search results.
	* The presets will show the balancing type (all are Automated, hence the gear), title, and when they were last updated underneath.

### Changed
* When switching balancing presets, the automatic note popup does not appear until you close the settings menu, meaning if you'd like to change other settings without seeing two pop-ups, you can now!
* The settings menu no longer displays which type of balancing your currently active preset is as this has been moved to the new balancing preset selection menu.
* The Balance Checker now only requests active balancing profiles when required.
	* Previously the site would load them all on launch, even if you didn't use them.
	* This has resulted in the following network improvements:
		* A whopping **45% reduction in startup time on average**.
		* There is now **20% less data transferred via the network on average**.

### Fixed
* Fixed a bug where importing builds would cause some methods to trigger multiple times.
* Numerous other bugs were fixed, unfortunately I do not have a full report on everything as many of these bugs were fixed due to the new balance preset selection process.

### Removed
* Removed a lot of redundant code that was built for older versions of the site or scrapped features.

### Known Issues
* Sometimes the new select preset button does not disappear if custom balancing is enabled (specifically if importing a build with custom balancing). This does not actually affect the site function at all, just is an unintended behaviour.

Thanks a ton!
 - Kyle